### PR TITLE
Only add members of organization not currently being followed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ###To Run
 1. Download the repository to your computer.
 2. From the command line, navigate to the peeps folder and `chmod u+x peeps.sh`.
-3. Enter `sh peeps.sh` to run the script.
+3. Enter `bash peeps.sh` to run the script.
 4. That's it!
 
 ###Note

--- a/peeps.sh
+++ b/peeps.sh
@@ -1,26 +1,29 @@
-#!/bin/bash
+#! /bin/bash
 #This script will automatically follow all of the users in a given Github organization (if you have access). 
 # Note: this only works if 2-Factor authorization is disabled.
  
 #1
-#get username for authentication
+# get username for authentication
 echo -n "Enter your Github username and press [ENTER]: "
 read name
+
  
 #2
 #grab existing token or authenticate user with necesarry permissions
 echo -n "Have you run this script before? (y/n) "
 read boolean
 
-if [ $boolean == "y" ]
+if [ $boolean = "y" ]
 then
 	curl -Ss -u $name https://api.github.com/authorizations > cred.txt
 	#!/usr/bin/env python
 	token="$(python pyscripts/parsetoken.py)"
+	echo $token
 else
-	curl -Ss -u $name -d '{"scopes": ["user", "read:org"], "note": "follow peeps"}' https://api.github.com/authorizations > cred.txt
+	curl -Ss -u $name -d '{"scopes": ["user", "read:org","user:follow"], "note": "follow peeps"}' https://api.github.com/authorizations > cred.txt
 	#!/usr/bin/env python
 	token="$(python pyscripts/parsetoken2.py)"
+	echo $token
 fi
 
 #4 
@@ -28,44 +31,70 @@ fi
 echo -n "Enter the Github organization whose peeps you would like to follow and press [ENTER]: "
 read org
 
+# find number of pages for followers
+curl -I -u $token:x-oauth-basic https://api.github.com/user/following > numpagesFollowers.txt	
+
+# get number of pages
+#!/usr/bin/env python
+numpagesFollowers="$(python pyscripts/parsenumpages.py)"
+# List of people user is following:
+COUNTER2=$numpagesFollowers
+echo "following pages "$COUNTER2
+until [ $COUNTER2 -le 0 ]; do
+	curl -Ss -u  $token:x-oauth-basic https://api.github.com/user/following?page=$COUNTER2 >> already.txt
+	# for any POSIX compatible shell, use this notation rather than let:
+	COUNTER2=$(($COUNTER2-1))
+done
+
 #3
 #get number of pages to pull membership data from (necessary due to github pagination, see https://developer.github.com/guides/traversing-with-pagination/)
-curl -I -u $token:x-oauth-basic https://api.github.com/orgs/$org/members > numpages.txt
+curl -I -u $token:x-oauth-basic https://api.github.com/orgs/$org/members > numpages.txt	
 
 # get number of pages
 #!/usr/bin/env python
 numpages="$(python pyscripts/parsenumpages.py)"
+# echo $numpages
 
 #4
-#Create member list file
+#Create organization member list file
 COUNTER=$numpages
-until [ $COUNTER -lt 0 ]; do
+until [ $COUNTER -le 0 ]; do
 	curl -Ss -u $token:x-oauth-basic https://api.github.com/orgs/$org/members?page=$COUNTER >> members.txt
-	let COUNTER-=1
+	# for any POSIX compatible shell, use this notation rather than let:
+	COUNTER=$(($COUNTER-1))
 done
- 
-#5
-#need to parse data from GET request for user logins and store in variable <users> here
-#!/usr/bin/env python
+
+# 5
+# need to parse data from GET request for user logins and store in variable <users> here
+# !/usr/bin/env python
 LOGINS="$(python pyscripts/parselogins.py)"
- 
+echo "New peeps to be followed: "$LOGINS
 #6
 #follow all users
-echo "Following all users in "$org", please wait..."
+echo "Following remaining users in "$org", please wait..."
+x=0
 for i in ${LOGINS[@]};
   do 
-    response=$(curl --silent --write-out %{http_code} --output /dev/null -u $token:x-oauth-basic -X PUT https://api.github.com/user/following/$i)
- 	if [ $response == "204" ]
- 		then
- 		echo "You are now following: "$i
- 	else
- 		echo "There was a problem following: "$i
- 	fi
+	# echo $i
+	if [[ "$i" != "$name" ]]
+		then
+    	response=$(curl --silent --write-out %{http_code} --output /dev/null -u $token:x-oauth-basic -X PUT https://api.github.com/user/following/$i)
+	 	if [ $response == "204" ]
+	 		then
+	 		echo "You are now following: "$i
+	 		x=$(($x+1))
+	 	else
+	 		echo $response
+	 		echo "There was a problem following: "$i
+	 	fi
+	fi
  	sleep .01
   done
-
+echo "You just followed an additional "$x" people!"
 #7
 #clean up
 rm ./members.txt
+rm ./already.txt
 rm ./cred.txt
 rm ./numpages.txt
+rm ./numpagesFollowers.txt

--- a/peeps.sh
+++ b/peeps.sh
@@ -13,7 +13,7 @@ read name
 echo -n "Have you run this script before? (y/n) "
 read boolean
 
-if [ $boolean = "y" ]
+if [ $boolean = "y" ];
 then
 	curl -Ss -u $name https://api.github.com/authorizations > cred.txt
 	#!/usr/bin/env python
@@ -26,75 +26,89 @@ else
 	echo $token
 fi
 
-#4 
-#find members of given github organization
-echo -n "Enter the Github organization whose peeps you would like to follow and press [ENTER]: "
-read org
+# looks to see if we receive a token. 
+	# if we do, we run through the script, and clear the files.
+	# if not, we report exiting program through validation error
+if [ "$token" != "" ];
+then
+	
+	#4 
+	#find members of given github organization
+	echo -n "Enter the Github organization whose peeps you would like to follow and press [ENTER]: "
+	read org
 
-# find number of pages for followers
-curl -I -u $token:x-oauth-basic https://api.github.com/user/following > numpagesFollowers.txt	
+	# find number of pages for followers
+	curl -I -u $token:x-oauth-basic https://api.github.com/user/following > numpagesFollowers.txt	
 
-# get number of pages
-#!/usr/bin/env python
-numpagesFollowers="$(python pyscripts/parsenumpages.py)"
-# List of people user is following:
-COUNTER2=$numpagesFollowers
-echo "following pages "$COUNTER2
-until [ $COUNTER2 -le 0 ]; do
-	curl -Ss -u  $token:x-oauth-basic https://api.github.com/user/following?page=$COUNTER2 >> already.txt
-	# for any POSIX compatible shell, use this notation rather than let:
-	COUNTER2=$(($COUNTER2-1))
-done
+	# get number of pages
+	#!/usr/bin/env python
+	numpagesFollowers="$(python pyscripts/parsenumpages.py)"
+	# List of people user is following:
+	COUNTER2=$numpagesFollowers
+	echo "following pages "$COUNTER2
+	# quoting in comparisons to avoid unary operator error
+	until [ "$COUNTER2" -le 0 ]; do
+		curl -Ss -u  $token:x-oauth-basic https://api.github.com/user/following?page=$COUNTER2 >> already.txt
+		# for any POSIX compatible shell, use this notation rather than let:
+		COUNTER2=$(($COUNTER2-1))
+	done
 
-#3
-#get number of pages to pull membership data from (necessary due to github pagination, see https://developer.github.com/guides/traversing-with-pagination/)
-curl -I -u $token:x-oauth-basic https://api.github.com/orgs/$org/members > numpages.txt	
+	#3
+	#get number of pages to pull membership data from (necessary due to github pagination, see https://developer.github.com/guides/traversing-with-pagination/)
+	curl -I -u $token:x-oauth-basic https://api.github.com/orgs/$org/members > numpages.txt	
 
-# get number of pages
-#!/usr/bin/env python
-numpages="$(python pyscripts/parsenumpages.py)"
-# echo $numpages
+	# get number of pages
+	#!/usr/bin/env python
+	numpages="$(python pyscripts/parsenumpages.py)"
+	# echo $numpages
 
-#4
-#Create organization member list file
-COUNTER=$numpages
-until [ $COUNTER -le 0 ]; do
-	curl -Ss -u $token:x-oauth-basic https://api.github.com/orgs/$org/members?page=$COUNTER >> members.txt
-	# for any POSIX compatible shell, use this notation rather than let:
-	COUNTER=$(($COUNTER-1))
-done
+	#4
+	#Create organization member list file
+	COUNTER=$numpages
+	# quoting in comparisons to avoid unary operator error
+	until [ "$COUNTER" -le 0 ]; do
+		curl -Ss -u $token:x-oauth-basic https://api.github.com/orgs/$org/members?page=$COUNTER >> members.txt
+		# for any POSIX compatible shell, use this notation rather than let:
+		COUNTER=$(($COUNTER-1))
+	done
 
-# 5
-# need to parse data from GET request for user logins and store in variable <users> here
-# !/usr/bin/env python
-LOGINS="$(python pyscripts/parselogins.py)"
-echo "New peeps to be followed: "$LOGINS
-#6
-#follow all users
-echo "Following remaining users in "$org", please wait..."
-x=0
-for i in ${LOGINS[@]};
-  do 
-	# echo $i
-	if [[ "$i" != "$name" ]]
-		then
-    	response=$(curl --silent --write-out %{http_code} --output /dev/null -u $token:x-oauth-basic -X PUT https://api.github.com/user/following/$i)
-	 	if [ $response == "204" ]
-	 		then
-	 		echo "You are now following: "$i
-	 		x=$(($x+1))
-	 	else
-	 		echo $response
-	 		echo "There was a problem following: "$i
-	 	fi
-	fi
- 	sleep .01
-  done
-echo "You just followed an additional "$x" people!"
-#7
-#clean up
-rm ./members.txt
-rm ./already.txt
-rm ./cred.txt
-rm ./numpages.txt
-rm ./numpagesFollowers.txt
+	# 5
+	# need to parse data from GET request for user logins and store in variable <users> here
+	# !/usr/bin/env python
+	LOGINS="$(python pyscripts/parselogins.py)"
+	echo "New peeps to be followed: "$LOGINS
+	#6
+	#follow all users
+	echo "Following remaining users in "$org", please wait..."
+	x=0
+	for i in ${LOGINS[@]};
+	  do 
+		# echo $i
+		if [[ "$i" != "$name" ]]
+			then
+	    	response=$(curl --silent --write-out %{http_code} --output /dev/null -u $token:x-oauth-basic -X PUT https://api.github.com/user/following/$i)
+		 	if [ $response == "204" ]
+		 		then
+		 		echo "You are now following: "$i
+		 		x=$(($x+1))
+		 	else
+		 		echo $response
+		 		echo "There was a problem following: "$i
+		 	fi
+		fi
+	 	sleep .01
+	  done
+	echo "You just followed an additional "$x" people!"
+
+	#7
+	#clean up
+	rm ./members.txt
+	rm ./already.txt
+	rm ./cred.txt
+	rm ./numpages.txt
+	rm ./numpagesFollowers.txt
+
+else
+	echo "Exiting program with token validation error"
+
+fi

--- a/pyscripts/parsealready.py
+++ b/pyscripts/parsealready.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import re
+
+data=open("already.txt").read()
+
+def findLogins():
+	users = data.split('login')
+	# print "fsdfs",len(users)
+	count=0
+	logins = []
+	for user in users:
+		str(user)
+		loginLine = user.splitlines()[0]
+		login = re.sub(r'[^a-zA-Z0-9\-]', '', loginLine)
+		logins.append(login)
+		if len(login)>0:
+			count+=1
+	logins.pop(0)
+	bashArray = ' '.join(logins)
+	return bashArray
+
+findLogins()

--- a/pyscripts/parselogins.py
+++ b/pyscripts/parselogins.py
@@ -3,17 +3,32 @@
 import re
 
 data=open("members.txt").read()
-
-def findLogins():
+data_already=open("already.txt").read()
+def findLogins(data):
 	users = data.split('login')
+	# print "fsdfs",len(users)
+	count=0
 	logins = []
 	for user in users:
 		str(user)
 		loginLine = user.splitlines()[0]
 		login = re.sub(r'[^a-zA-Z0-9\-]', '', loginLine)
 		logins.append(login)
+		if len(login)>0:
+			count+=1
 	logins.pop(0)
-	bashArray = ' '.join(logins)
-	print bashArray
+	# bashArray = ' '.join(logins)
+	#print bashArray,"count",count
+	return logins
 
-findLogins()
+def findNotYet(new,present):
+	toBeAdded=[]
+	for i in new:
+		if not(i in present):
+			toBeAdded.append(i)
+	toBeAddedString=' '.join(toBeAdded)
+	print toBeAddedString
+
+already=findLogins(data_already)
+logins=findLogins(data)
+notYet=findNotYet(logins,already)

--- a/pyscripts/parsenumpages.py
+++ b/pyscripts/parsenumpages.py
@@ -3,7 +3,7 @@
 data=open("numpages.txt").read()
 
 def findPages():
-	numpages = 'There is a pagination error, please notify the developers : )'
+	# numpages = 'There is a pagination error, please notify the developers : )'
 	splitData = data.split('page=')
 	for i in splitData:
 		str(i)
@@ -12,6 +12,6 @@ def findPages():
 			line = lines[0]
 			splitLine = line.split('>')
 			numpages = splitLine[0]
-	print numpages
+	# print numpages
 
 findPages()

--- a/pyscripts/parsetoken2.py
+++ b/pyscripts/parsetoken2.py
@@ -3,6 +3,7 @@
 # Parses a token for follow peeps from a newly created, single authentication.
 
 import json
+import unicodedata
 
 json_data=open("cred.txt").read()
 data = json.loads(json_data)

--- a/pyscripts/parsetoken2.py
+++ b/pyscripts/parsetoken2.py
@@ -9,10 +9,17 @@ json_data=open("cred.txt").read()
 data = json.loads(json_data)
 
 def findToken():
-	if data['note'] == "follow peeps":
-		token = data['token']
-		print token
-	else:
+	if data['errors']:
+		print 'Errors found: ',data['message'],
+		print data['errors'][0]['resource']
+		print data['errors'][0]['code']
+		print data['documentation_url']
 		print 'There is an error in retrieving your token!'
+		return ""
+
+	elif data['note']:
+		if data['note'] == "follow peeps":
+			token = data['token']
+			return token
 
 findToken()


### PR DESCRIPTION
Modified it to only add members of the organization that the user is not currently following. 
- Added a little code that ignores current user if user is member of organization. 
- Provided a little stat of how many users are being added. 
  - This might be a little buggy, need to test it more.
- Next on agenda is to have a better check if the script has already been run instead of asking the user.
